### PR TITLE
fix: change log for schema snapshot postgres

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -187,7 +187,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
                 throw new InterruptedException("Interrupted while reading structure of schema " + schema);
             }
 
-            LOGGER.info("Reading structure of schema '{}'", snapshotContext.catalogName);
+            LOGGER.info("Reading structure of schema '{}' of catalog '{}'", schema, snapshotContext.catalogName);
             jdbcConnection.readSchema(
                     snapshotContext.tables,
                     snapshotContext.catalogName,


### PR DESCRIPTION
The current log isn't informative enough due to a repeat of the same information : 
```
2022-03-15 10:16:35,352 INFO Reading structure of schema 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChangeEventSource) [debezium-postgresconnector-postgres-mu │
│ 2022-03-15 10:16:36,106 INFO Reading structure of schema 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChangeEventSource) [debezium-postgresconnector-postgres-mu │
│ 2022-03-15 10:16:36,647 INFO Reading structure of schema 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChangeEventSource) [debezium-postgresconnector-postgres-mu │
│ 2022-03-15 10:16:37,171 INFO Reading structure of schema 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChangeEventSource) [debezium-postgresconnector-postgres-mu │
│ 2022-03-15 10:16:37,772 INFO Reading structure of schema 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChangeEventSource) [debezium-postgresconnector-postgres-mu │
│ 2022-03-15 10:16:38,324 INFO Reading structure of schema 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChangeEventSource) [debezium-postgresconnector-postgres-mu │
...
```

Adding the current schema read seems more in line with what this log was meant to do :
```
2022-03-15 13:16:35,404 INFO Reading structure of schema 'dataset_bd1f6a46_91ee_412d_8cd5_6cd3b568fb21' of catalog 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChan
2022-03-15 13:16:35,871 INFO Reading structure of schema 'dataset_0406a667_a69c_4eef_8c4a_bd1ce40b6839' of catalog 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChan
2022-03-15 13:16:36,391 INFO Reading structure of schema 'dataset_a73ac194_ad36_4bae_96b2_493d5a5f1ca8' of catalog 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChan
2022-03-15 13:16:37,315 INFO Reading structure of schema 'dataset_5cb27897_3000_4253_99fc_0a4cb3921137' of catalog 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChan
2022-03-15 13:16:37,755 INFO Reading structure of schema 'dataset_657e07b0_9835_4ba8_94b9_0ce6dc50cc04' of catalog 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChan
2022-03-15 13:16:38,211 INFO Reading structure of schema 'dataset_bc90dc90_50a0_4708_8d03_46990fd86d63' of catalog 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChan
2022-03-15 13:16:38,679 INFO Reading structure of schema 'dataset_3631dd10_e2e6_4502_96dd_97b17add49cc' of catalog 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChan
2022-03-15 13:16:39,134 INFO Reading structure of schema 'dataset_6bc5d0a4_6a7d_424b_abb9_88d055241c71' of catalog 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChan
2022-03-15 13:16:39,571 INFO Reading structure of schema 'dataset_af4d66f1_0ff9_4366_8e9e_f2cfe884e13b' of catalog 'dataset_tenants' (io.debezium.connector.postgresql.PostgresSnapshotChan

```